### PR TITLE
chore: update from Node.js 20 -> 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Integration tests
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.24.4
           cache-dependency-path: tests/go.sum

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate Go SDK
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: generate-token
         with:
           app-id: ${{ secrets.VULNCHECK_GITHUB_RELEASE_APP_ID }}
           private-key: ${{ secrets.VULNCHECK_GITHUB_RELEASE_APP_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install cog
         run: pip install cogapp==3.6.0
       - name: Generate new sdk
@@ -34,7 +34,7 @@ jobs:
             echo "changes=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         if: steps.generate.outputs.changes == 'true'
         with:
           go-version: 1.24.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,20 +18,20 @@ jobs:
     runs-on: ubuntu-latest
     name: Create Release
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: generate_token
         with:
           app-id: ${{ secrets.VULNCHECK_GITHUB_RELEASE_APP_ID }}
           private-key: ${{ secrets.VULNCHECK_GITHUB_RELEASE_APP_KEY }}
 
       - name: Check out HEAD ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
           path: head
           fetch-tags: true
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.24.4
           cache-dependency-path: head/tests/go.sum
@@ -59,7 +59,7 @@ jobs:
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
 
       - name: Check out previous release
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           path: previous


### PR DESCRIPTION
softprops/action-gh-release@v2 does not have a Node.js 24 version yet.